### PR TITLE
fix: pass FastAPI app object directly to uvicorn.run instead of string import

### DIFF
--- a/chirrup/web_service/app.py
+++ b/chirrup/web_service/app.py
@@ -629,4 +629,4 @@ if __name__ == "__main__":
     config = get_config()
 
     # 启动服务器
-    uvicorn.run("app:app", host=config.host, port=config.port, reload=False, log_level="info")
+    uvicorn.run(app, host=config.host, port=config.port, reload=False, log_level="info")


### PR DESCRIPTION
When running the module with `python -m chirrup.web_service.app`, uvicorn
failed to import the app using the string "app:app" because the module name
was set to `chirrup.web_service.app`, causing import resolution to fail.

Passing the `app` FastAPI object directly to `uvicorn.run()` avoids string-based
module imports and works regardless of how the module is invoked.

Original command:
```
PYTHON_GIL=0 uv run python -m chirrup.web_service.app --model_path ./models/rwkv7-g1a3-2.9b-20251103-ctx8192.pth
```

Original error:
```
ERROR:    Error loading ASGI app. Could not import module "app".
```